### PR TITLE
Correct format specifiers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ else
 LIBDIR = lib
 endif
 
-CFLAGS += -std=gnu11 -Wall -Werror -D_GNU_SOURCE=1 -fPIC $(PYTHONINCLUDE)
+CFLAGS += -std=gnu11 -Wall -D_GNU_SOURCE=1 -fPIC $(PYTHONINCLUDE)
 
 OBJECTS = md5.o libimplantisomd5.o checkisomd5.o implantisomd5
 SOURCES = $(patsubst %.o,%.c,$(OBJECTS))

--- a/libcheckisomd5.c
+++ b/libcheckisomd5.c
@@ -142,7 +142,7 @@ int printMD5SUM(char *file) {
     printf("%s:   %s\n", file, info->hashsum);
     if (strlen(info->fragmentsums) > 0 && info->fragmentcount > 0) {
         printf("Fragment sums: %s\n", info->fragmentsums);
-        printf("Fragment count: %ld\n", info->fragmentcount);
+        printf("Fragment count: %zu\n", info->fragmentcount);
         printf("Supported ISO: %s\n", info->supported ? "yes" : "no");
     }
     free(info);

--- a/libimplantisomd5.c
+++ b/libimplantisomd5.c
@@ -131,7 +131,7 @@ int implantISOFile(char *fname, int supported, int forceit, int quiet, char **er
         printf("md5 = %s\n", hashsum);
         printf("Inserting fragment md5sums into iso image...\n");
         printf("fragmd5 = %s\n", fragmentsums);
-        printf("frags = %ld\n", FRAGMENT_COUNT);
+        printf("frags = %lu\n", FRAGMENT_COUNT);
     }
     memset(appdata, ' ', APPDATA_SIZE);
 
@@ -170,7 +170,7 @@ int implantISOFile(char *fname, int supported, int forceit, int quiet, char **er
     if (writeAppData(appdata, ";", &loc, errstr))
         goto fail;
 
-    snprintf(appdata_buffer, APPDATA_SIZE, "FRAGMENT COUNT = %ld", FRAGMENT_COUNT);
+    snprintf(appdata_buffer, APPDATA_SIZE, "FRAGMENT COUNT = %lu", FRAGMENT_COUNT);
     if (writeAppData(appdata, appdata_buffer, &loc, errstr))
         goto fail;
     if (writeAppData(appdata, ";", &loc, errstr))


### PR DESCRIPTION
and don't fail builds due to warnings. Should fix #4.