### PR TITLE
Let the user pass their own file descriptor

### DIFF
--- a/libcheckisomd5.c
+++ b/libcheckisomd5.c
@@ -125,6 +125,12 @@ int mediaCheckFile(char *file, checkCallback cb, void *cbdata) {
     if (isofd < 0) {
         return ISOMD5SUM_FILE_NOT_FOUND;
     }
+    int rc = checkmd5sum(isofd, cb, cbdata);
+    close(isofd);
+    return rc;
+}
+
+int mediaCheckFD(int isofd, checkCallback cb, void *cbdata) {
     return checkmd5sum(isofd, cb, cbdata);
 }
 

--- a/libcheckisomd5.h
+++ b/libcheckisomd5.h
@@ -15,6 +15,7 @@ enum isomd5sum_status {
 typedef int (*checkCallback)(void *, off_t offset, off_t total);
 
 int mediaCheckFile(char *iso, checkCallback cb, void *cbdata);
+int mediaCheckFD(int isofd, checkCallback cb, void *cbdata);
 int printMD5SUM(char *file);
 
 #endif

--- a/libimplantisomd5.h
+++ b/libimplantisomd5.h
@@ -1,5 +1,6 @@
 #ifndef __LIBIMPLANTISOMD5_H__
 #define __LIBIMPLANTISOMD5_H__
 int implantISOFile(char *iso, int supported, int forceit, int quiet, char **errstr);
+int implantISOFD(int isofd, int supported, int forceit, int quiet, char **errstr);
 #endif
 


### PR DESCRIPTION
Make sure to close file descriptors when the user doesn't manage them.