### PR TITLE
testpyisomd5sum.py: Support genisoimage, Python 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,4 +73,4 @@ archive:
 	@echo "The final archive is in isomd5sum-$(VERSION).tar.bz2"
 
 test:
-	./testpyisomd5sum.py
+	$(PYTHON) ./testpyisomd5sum.py

--- a/testpyisomd5sum.py
+++ b/testpyisomd5sum.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 import os
+import subprocess
 import pyisomd5sum
 
 # Pass in the rc, the expected value and the pass_all state
@@ -13,7 +14,16 @@ def pass_fail(rc, pass_value, pass_all):
 
 
 # create iso file
-os.system("mkisofs -quiet . > testiso.iso")
+try:
+    # Python 3
+    catch_error = FileNotFoundError
+except NameError:
+    # Python 2
+    catch_error = OSError
+try:
+    subprocess.check_call(["mkisofs", "-quiet", "-o", "testiso.iso", "."])
+except catch_error:
+    subprocess.check_call(["genisoimage", "-quiet", "-o", "testiso.iso", "."])
 
 # implant it
 (rstr, pass_all) = pass_fail(pyisomd5sum.implantisomd5sum("testiso.iso", 1, 0), 0, True)


### PR DESCRIPTION
Debian-based distributions no longer contain mkisofs, so use
genisoimage is mkisofs is not found.  This is done in a way which is
compatible with both Python 2 and Python 3.  Honor $(PYTHON) in Makefile
when calling testpyisomd5sum.py during make test.